### PR TITLE
issue-7684 | Preserve url hash during rules table filtering

### DIFF
--- a/packages/website/src/components/RulesTable/index.tsx
+++ b/packages/website/src/components/RulesTable/index.tsx
@@ -245,6 +245,7 @@ const neutralFiltersState: FiltersState = {
 
 const selectSearch: HistorySelector<string> = history =>
   history.location.search;
+const selectHash: HistorySelector<string> = history => history.location.hash;
 const getServerSnapshot = (): string => '';
 
 function useRulesFilters(
@@ -252,6 +253,7 @@ function useRulesFilters(
 ): [FiltersState, (category: FilterCategory, mode: FilterMode) => void] {
   const history = useHistory();
   const search = useHistorySelector(selectSearch, getServerSnapshot);
+  const hash = useHistorySelector(selectHash, getServerSnapshot);
 
   const paramValue = new URLSearchParams(search).get(paramsKey) ?? '';
   // We can't compute this in selectSearch, because we need the snapshot to be
@@ -287,7 +289,7 @@ function useRulesFilters(
       searchParams.delete(paramsKey);
     }
 
-    history.replace({ search: searchParams.toString() });
+    history.replace({ hash, search: searchParams.toString() });
   };
 
   return [filtersState, changeFilter];


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to typescript-eslint! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR.
-->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7684
- [ ] That issue was marked as [accepting prs](https://github.com/typescript-eslint/typescript-eslint/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [Contributing](https://typescript-eslint.io/contributing) were taken

## Overview

Function responsible for translating selected filters to url search parameters was not preserving hash in url. It resulted in hash being removed and [Rules page](https://typescript-eslint.io/rules/) jumping to the top of content whenever user has used filter while having any hash in url. 

This small fix will keep hash from being removed when filtering.
